### PR TITLE
nginx as proxy

### DIFF
--- a/README.md
+++ b/README.md
@@ -257,17 +257,19 @@ Now you have the Spark Cluster running and you can proceed with the next step.
 
 We are ready to prepare the notebook host, that will serve users with temporary notebook instances.
 
-First, open network access to your current IP for testing the setup internally. Go to cPouta www-interface and
-add a security group rule to your cluster's <cluster-name>-notebook -group.
+First, open network access to your current IP for testing the setup internally. If you want to serve the notebooks 
+to users over plain http, open port 80. If you would like to use https, use open 443. You can also open both
+ports by creating two rules. Go to cPouta www-interface and add security group rules to your cluster's 
+<cluster-name>-notebook -group. 
  
  * protocol: TCP
- * port 80
+ * port 80 or 443
  * CIDR: your IP x.y.z.t/32 (take a look at 'ip a' or check it online, search for "what is my ipv4")
 
 SSH in to the notebook host using its private IP from your bastion host.
 
-There is an nginx proxy process forwarding traffic from port 80 to tmpnb at port 8000. This also takes
-care of authentication. Add user/password to nginx htaccess file on the notebook host
+There is an nginx proxy process forwarding traffic from ports 80 (http) and 443 (https) to tmpnb at port 8000. 
+The proxy also takes care of authentication. Add user/password to nginx htaccess file on the notebook host
   
     sudo htpasswd -c /etc/nginx/.htpasswd example_user
 
@@ -310,6 +312,7 @@ timeout (cull_timeout) is set to 15 minutes. The option -it keeps tmpnb in the f
                 "--NotebookApp.base_url={base_path} \
                 --ip=0.0.0.0 \
                 --port={port} \
+                --NotebookApp.allow_origin=* \
                 --NotebookApp.trust_xheaders=True"'
 
 After the containers start running (Can be checked by `sudo docker ps -a`), open the browser and point it to 

--- a/README.md
+++ b/README.md
@@ -261,10 +261,15 @@ First, open network access to your current IP for testing the setup internally. 
 add a security group rule to your cluster's <cluster-name>-notebook -group.
  
  * protocol: TCP
- * port 8000
+ * port 80
  * CIDR: your IP x.y.z.t/32 (take a look at 'ip a' or check it online, search for "what is my ipv4")
 
 SSH in to the notebook host using its private IP from your bastion host.
+
+There is an nginx proxy process forwarding traffic from port 80 to tmpnb at port 8000. This also takes
+care of authentication. Add user/password to nginx htaccess file on the notebook host
+  
+    sudo htpasswd -c /etc/nginx/.htpasswd example_user
 
 On the notebook host, Add a directory to HDFS for the notebook user
 
@@ -287,10 +292,6 @@ Setup the proxy first to run tmpnb
     
     sudo docker run --net=host -d -e CONFIGPROXY_AUTH_TOKEN=$TOKEN --name=proxy jupyter/configurable-http-proxy --default-target http://127.0.0.1:9999
 
-Generate a password hash for the notebooks
-
-    sudo docker run jupyter/pyspark-notebook python3 -c "from IPython.lib import passwd; print(passwd('dont_use_this'))"
-    
 Now run the image which we just built and tagged. This runs 2 notebook containers (pool_size), the inactivity 
 timeout (cull_timeout) is set to 15 minutes. The option -it keeps tmpnb in the foreground - good for debugging. 
 
@@ -309,11 +310,10 @@ timeout (cull_timeout) is set to 15 minutes. The option -it keeps tmpnb in the f
                 "--NotebookApp.base_url={base_path} \
                 --ip=0.0.0.0 \
                 --port={port} \
-                --NotebookApp.password=THE_HASH_FROM_ABOVE \
                 --NotebookApp.trust_xheaders=True"'
 
 After the containers start running (Can be checked by `sudo docker ps -a`), open the browser and point it to 
-http://\<public-ip-of-the-notebook-host>:8000
+http://\<public-ip-of-the-notebook-host>
 
 Now open a Jupyter Python3 notebook and write the following code.
 

--- a/playbooks/cluster.yml
+++ b/playbooks/cluster.yml
@@ -290,3 +290,13 @@
   become: yes
   roles:
     - notebook_host
+
+- name: Print resource info
+  hosts:
+    - localhost
+  tasks:
+  - debug:
+      msg: >
+        Master has private IP {{ master_vm.openstack.private_v4 }}.
+        Notebook has private IP {{ notebook_vm.openstack.private_v4 }} and
+        public IP {{ notebook_vm.openstack.public_v4 }}.

--- a/playbooks/roles/ambari_server/tasks/main.yml
+++ b/playbooks/roles/ambari_server/tasks/main.yml
@@ -1,4 +1,4 @@
-- name: Add ambari repository
+- name: add ambari repository
   get_url:
     url: http://public-repo-1.hortonworks.com/ambari/centos7/2.x/updates/2.2.0.0/ambari.repo
     dest: /etc/yum.repos.d/ambari.repo
@@ -16,7 +16,7 @@
     mode: 0600
     state: directory
 
-- name: Create self-signed SSL cert
+- name: create self-signed SSL cert
   command: >
     openssl req -new -nodes -x509
     -subj "/C=FI/ST=SouthernFinland/L=Espoo/O=IT/CN={{ ansible_hostname }}"
@@ -29,6 +29,8 @@
 
 - name: run ambari setup
   shell: ambari-server setup -j /etc/alternatives/jre -s
+  args:
+    creates: /etc/ambari-server/conf/password.dat
 
 - name: start ambari service
   service: name=ambari-server state=running enabled=yes

--- a/playbooks/roles/conda/tasks/main.yml
+++ b/playbooks/roles/conda/tasks/main.yml
@@ -5,3 +5,5 @@
 
 - name: install miniconda to /opt/conda
   shell: /bin/bash /tmp/miniconda.sh -f -b -p /opt/conda
+  args:
+    creates: /opt/conda

--- a/playbooks/roles/notebook_host/handlers/main.yml
+++ b/playbooks/roles/notebook_host/handlers/main.yml
@@ -1,6 +1,9 @@
 - name: restart docker
   service: name=docker state=restarted
 
+- name: restart nginx
+  service: name=nginx state=restarted
+
 # if we restart iptables, dockerd needs to be restarted, too
 - name: restart iptables
   service: name={{ item }} state=restarted

--- a/playbooks/roles/notebook_host/tasks/main.yml
+++ b/playbooks/roles/notebook_host/tasks/main.yml
@@ -6,12 +6,29 @@
 - name: install docker
   yum: name=docker state=present
 
-- name: Upload custom docker storage configuration
+- name: upload custom docker storage configuration
   template:
-    src=etc/sysconfig/docker-storage.j2
-    dest=/etc/sysconfig/docker-storage
-    backup=True
+    src: etc/sysconfig/docker-storage.j2
+    dest: /etc/sysconfig/docker-storage
+    backup: True
   notify: restart docker
 
 - name: enable docker service
   service: name=docker state=running enabled=yes
+
+- name: install nginx and httpd-tools
+  yum: name={{ item }} state=present
+  with_items:
+    - nginx
+    - httpd-tools
+
+- name: copy proxy config to nginx
+  template:
+    src: etc/nginx/nginx.conf.j2
+    dest: /etc/nginx/nginx.conf
+    backup: True
+  notify: restart nginx
+
+- name: enable nginx service
+  service: name=nginx state=running enabled=yes
+

--- a/playbooks/roles/notebook_host/tasks/main.yml
+++ b/playbooks/roles/notebook_host/tasks/main.yml
@@ -16,6 +16,24 @@
 - name: enable docker service
   service: name=docker state=running enabled=yes
 
+- name: create certificate dir
+  file:
+    dest: "/etc/nginx/ssl"
+    owner: root
+    group: root
+    mode: 0600
+    state: directory
+
+- name: create self-signed SSL cert
+  command: >
+    openssl req -new -nodes -x509
+    -subj "/C=FI/ST=SouthernFinland/L=Espoo/O=IT/CN={{ ansible_hostname }}"
+    -days 3650
+    -extensions v3_ca
+    -keyout /etc/nginx/ssl/server.key
+    -out /etc/nginx/ssl/server.crt
+    creates=/etc/nginx/ssl/server.crt
+
 - name: install nginx and httpd-tools
   yum: name={{ item }} state=present
   with_items:

--- a/playbooks/roles/notebook_host/templates/etc/nginx/nginx.conf.j2
+++ b/playbooks/roles/notebook_host/templates/etc/nginx/nginx.conf.j2
@@ -37,8 +37,34 @@ http {
         server_name  _;
         root         /usr/share/nginx/html;
 
-        # Load configuration files for the default server block.
-        include /etc/nginx/default.d/*.conf;
+        location / {
+            proxy_pass   http://localhost:8000;
+            proxy_set_header Upgrade $http_upgrade;
+            proxy_set_header Connection "upgrade";
+            proxy_set_header Host $host;
+
+            auth_basic "Restricted";
+            auth_basic_user_file /etc/nginx/.htpasswd;
+        }
+
+        error_page 404 /404.html;
+            location = /40x.html {
+        }
+
+        error_page 500 502 503 504 /50x.html;
+            location = /50x.html {
+        }
+    }
+
+    server {
+        listen       443 ssl;
+        server_name  _;
+        root         /usr/share/nginx/html;
+
+        ssl on;
+        ssl_certificate           /etc/nginx/ssl/server.crt;
+        ssl_certificate_key       /etc/nginx/ssl/server.key;
+        ssl_protocols TLSv1 TLSv1.1 TLSv1.2;
 
         location / {
             proxy_pass   http://localhost:8000;
@@ -58,4 +84,5 @@ http {
             location = /50x.html {
         }
     }
+
 }

--- a/playbooks/roles/notebook_host/templates/etc/nginx/nginx.conf.j2
+++ b/playbooks/roles/notebook_host/templates/etc/nginx/nginx.conf.j2
@@ -1,0 +1,61 @@
+# For more information on configuration, see:
+#   * Official English Documentation: http://nginx.org/en/docs/
+#   * Official Russian Documentation: http://nginx.org/ru/docs/
+
+user nginx;
+worker_processes auto;
+error_log /var/log/nginx/error.log;
+pid /run/nginx.pid;
+
+events {
+    worker_connections 1024;
+}
+
+http {
+    log_format  main  '$remote_addr - $remote_user [$time_local] "$request" '
+                      '$status $body_bytes_sent "$http_referer" '
+                      '"$http_user_agent" "$http_x_forwarded_for"';
+
+    access_log  /var/log/nginx/access.log  main;
+
+    sendfile            on;
+    tcp_nopush          on;
+    tcp_nodelay         on;
+    keepalive_timeout   65;
+    types_hash_max_size 2048;
+
+    include             /etc/nginx/mime.types;
+    default_type        application/octet-stream;
+
+    # Load modular configuration files from the /etc/nginx/conf.d directory.
+    # See http://nginx.org/en/docs/ngx_core_module.html#include
+    # for more information.
+    include /etc/nginx/conf.d/*.conf;
+
+    server {
+        listen       80 default_server;
+        server_name  _;
+        root         /usr/share/nginx/html;
+
+        # Load configuration files for the default server block.
+        include /etc/nginx/default.d/*.conf;
+
+        location / {
+            proxy_pass   http://localhost:8000;
+            proxy_set_header Upgrade $http_upgrade;
+            proxy_set_header Connection "upgrade";
+            proxy_set_header Host $host;
+
+            auth_basic "Restricted";
+            auth_basic_user_file /etc/nginx/.htpasswd;
+        }
+
+        error_page 404 /404.html;
+            location = /40x.html {
+        }
+
+        error_page 500 502 503 504 /50x.html;
+            location = /50x.html {
+        }
+    }
+}


### PR DESCRIPTION
- install and run nginx as an authenticating proxy in front of tmpnb
- print resource info at the end of ansible run
- some minor ansible cleanup
- moved authentication to nginx in instructions
