### PR TITLE
open access to udp port 53 from notebook

### DIFF
--- a/playbooks/cluster.yml
+++ b/playbooks/cluster.yml
@@ -73,6 +73,15 @@
       with_items: [6188, 7077, 8020, 8050, 8080, 8188, 8440, 8441]
       tags: ['secgroup_creation']
 
+    - name: master security group - open DNS from notebook
+      os_security_group_rule:
+        security_group: "{{ cluster_name }}-master"
+        remote_group: "{{ sg_notebook.secgroup.id }}"
+        protocol: "udp"
+        port_range_min: 53
+        port_range_max: 53
+      tags: ['secgroup_creation']
+
     - name: common security group - open access from notebook
       os_security_group_rule:
         security_group: "{{ cluster_name }}-common"


### PR DESCRIPTION
In case the cluster is expanded, changes in /etc/hosts are not visible in
notebook containers already running. Therefore we need to allow DNS queries to
the dnsmasq running on the frontend.
